### PR TITLE
Fix compilation for browser targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "types": "lib",
   "exports": {
     ".": {
+      "browser": {
+        "require": "./lib/browser.js",
+        "import": "./es/browser.mjs"
+      },
       "require": "./lib/index.js",
       "import": "./es/index.mjs"
     }

--- a/src/DirectConnection-stub.ts
+++ b/src/DirectConnection-stub.ts
@@ -1,0 +1,31 @@
+import type { Logger } from '@d-fischer/logger';
+import { AbstractConnection } from './AbstractConnection';
+import type { ConnectionInfo } from './Connection';
+
+export class DirectConnection extends AbstractConnection {
+	constructor(options: ConnectionInfo, logger?: Logger, additionalOptions?: never) {
+		throw new Error('DirectConnection is not implemented in a browser environment');
+		super(options, logger, additionalOptions);
+	}
+
+	get port(): number {
+		return this._port;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
+	get hasSocket(): boolean {
+		return false;
+	}
+
+	sendRaw(line: string): void {
+		void line;
+	}
+
+	async connect(): Promise<void> {
+		//
+	}
+
+	async disconnect(): Promise<void> {
+		//
+	}
+}

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,7 @@
+export { AbstractConnection } from './AbstractConnection';
+export type { ConnectionOptions } from './AbstractConnection';
+export type { Connection, ConnectionInfo } from './Connection';
+export { DirectConnection } from './DirectConnection-stub';
+export { PersistentConnection } from './PersistentConnection';
+export type { WebSocketConnectionOptions } from './WebSocketConnection';
+export { WebSocketConnection } from './WebSocketConnection';


### PR DESCRIPTION
The `DirectConnection` class imports the Node.js `net` and `tls` modules. For browser-targeted projects built with Webpack, Webpack 4 would mock those modules to allow compilation, though the resulting class would of course be nonfunctional. As of Webpack 5, that mocking no longer occurs by default, so these imports lead to compilation errors with browser targets (web and similar).

Since `DirectConnection` was never functional in browsers anyway, this PR adds an alternate browser build of this module that stubs `DirectConnection` to throw an error on construction.

Fixes #5 